### PR TITLE
make build step optional in spin deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,6 @@ jobs:
 
 ```
 
-
-
-
 ## Deploy Spin app to Fermyon Cloud - `fermyon/actions/spin/deploy@v1`
 
 Build and deploy the Spin app to Fermyon Cloud.
@@ -152,6 +149,8 @@ Build and deploy the Spin app to Fermyon Cloud.
 | fermyon_token | True     | -         | [Fermyon Cloud Personal Access Token](https://developer.fermyon.com/cloud/user-settings.md#create-and-manage-a-personal-access-token) for deploying the Spin app to Fermyon Cloud |
 | manifest_file | False    | spin.toml | Path to `spin.toml`.                                                                                                                                                              |
 | key_values    | False    | -         | Pass a key/value (key=value) to all components of the application. You can specify multiple key_values by putting each key/value pair on its own line. Refer to example below.    |
+| run_build     | False    | True      | If enabled, run `spin build`                                                                                                                                                      |
+
 ### Example
 
 

--- a/dist/spin/deploy/index.js
+++ b/dist/spin/deploy/index.js
@@ -23594,7 +23594,10 @@ const cloud = __importStar(__nccwpck_require__(7832));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield actions.build();
+            const buildEnabled = core.getBooleanInput('run_build') === false ? false : true;
+            if (buildEnabled) {
+                yield actions.build();
+            }
             const token = core.getInput('fermyon_token', { required: true });
             yield cloud.login(token);
             const metadata = yield actions.deploy();

--- a/spin/deploy/action.yml
+++ b/spin/deploy/action.yml
@@ -12,6 +12,10 @@ inputs:
   key_values:
     required: false
     description: 'Pass a key/value (key=value) to all components of the application. You can specify multiple key_values by putting each key/value pair on its own line'
+  run_build:
+    required: false
+    description: 'run `spin build` if enabled (default)'  
+    default: true
 runs:
   using: 'node16'
   main: '../../dist/spin/deploy/index.js'

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -4,7 +4,10 @@ import * as cloud from './cloud'
 
 async function run(): Promise<void> {
   try {
-    await actions.build()
+    const buildEnabled = core.getBooleanInput('run_build') === false ? false : true;
+    if (buildEnabled) {
+      await actions.build()
+    }
 
     const token = core.getInput('fermyon_token', { required: true })
     await cloud.login(token)


### PR DESCRIPTION
I have a scenario where I need to deploy a rust app to the cloud, but I don't want to build it every time as I check-in the wasm file with the code. it would be nice to have the option to skip build step for such scenarios.

thanks
Rajat Jindal