### PR TITLE
fix(docs/etc): update output name per code

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Build and deploy the Spin app to Fermyon Cloud.
 
 | Name    | Description                      |
 | ------- | -------------------------------- |
-| app_url | The URL of the deployed Spin app |
+| app-url | The URL of the deployed Spin app |
 
 ### Example
 
@@ -229,7 +229,7 @@ If you don't run the preview action with undeploy on the closed event, your prev
 
 | Name    | Description                              |
 | ------- | ---------------------------------------- |
-| app_url | The URL of the deployed Spin app preview |
+| app-url | The URL of the deployed Spin app preview |
 
 ### Example
 

--- a/spin/deploy/action.yml
+++ b/spin/deploy/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     description: 'Pass a variable (variable=value) to all components of the application. You can specify multiple variables by putting each variable/value pair on its own line'
 outputs:
-  app_url:
+  app-url:
     description: 'the URL of the deployed app'
 runs:
   using: 'node16'

--- a/spin/preview/action.yml
+++ b/spin/preview/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     description: 'Pass a variable (variable=value) to all components of the application. You can specify multiple variables by putting each variable/value pair on its own line'
 outputs:
-  app_url:
+  app-url:
     description: 'the URL of the deployed preview app'
 runs:
   using: 'node16'


### PR DESCRIPTION
- Updates docs references for the app URL output to `app-url` as used in the source code, eg https://github.com/fermyon/actions/blob/main/src/deploy.ts#L17