### PR TITLE
chore(.github): bump artifact actions to v4

### DIFF
--- a/.github/workflows/e2e-spin-deploy.yml
+++ b/.github/workflows/e2e-spin-deploy.yml
@@ -26,7 +26,7 @@ jobs:
           NODE_OPTIONS: --openssl-legacy-provider
 
       - name: upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spin-actions
           path: dist/spin/deploy/index.js
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Retrieve saved Github action
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spin-actions
           path: dist/spin/deploy/

--- a/.github/workflows/e2e-spin-preview.yml
+++ b/.github/workflows/e2e-spin-preview.yml
@@ -24,7 +24,7 @@ jobs:
           NODE_OPTIONS: --openssl-legacy-provider
 
       - name: upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spin-actions
           path: dist/spin/preview/index.js
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Retrieve saved Github action
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spin-actions
           path: dist/spin/preview/

--- a/.github/workflows/e2e-spin-push.yml
+++ b/.github/workflows/e2e-spin-push.yml
@@ -31,7 +31,7 @@ jobs:
           NODE_OPTIONS: --openssl-legacy-provider
 
       - name: upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spin-actions
           path: dist/spin/push/index.js
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Retrieve saved Github action
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spin-actions
           path: dist/spin/push/
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Retrieve saved Github action
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: spin-actions
           path: dist/spin/push/

--- a/.github/workflows/e2e-spin-setup.yml
+++ b/.github/workflows/e2e-spin-setup.yml
@@ -25,7 +25,7 @@ jobs:
           NODE_OPTIONS: --openssl-legacy-provider
 
       - name: upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: setup-spin
           path: dist/spin/setup/index.js
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Retrieve saved Github action
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup-spin
           path: dist/spin/setup/
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Retrieve saved Github action
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup-spin
           path: dist/spin/setup/
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Retrieve saved Github action
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup-spin
           path: dist/spin/setup/
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Retrieve saved Github action
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: setup-spin
           path: dist/spin/setup/


### PR DESCRIPTION
- Bumps the artifact actions to v4 per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions