### PR TITLE
feat(spin/preview): add run_build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ If you don't run the preview action with undeploy on the closed event, your prev
 | github_token  | True     | -         | The GitHub token for adding a comment on PR with preview URL.                   |
 | undeploy      | False    | -         | If true, removes the preview deployment from Fermyon Cloud                      |
 | key_values    | False    | -         | Pass one or more key/value pairs to the default store for all components"       |
+| run_build     | False    | True      | If enabled, run `spin build`                                                    |
 | variables     | False    | -         | Pass a variable (variable=value) to all components of the application. You can specify multiple variables by putting each variable/value pair on its own line. Refer to example below. |
 
 ### Outputs

--- a/dist/spin/preview/index.js
+++ b/dist/spin/preview/index.js
@@ -23975,7 +23975,10 @@ function run() {
             }
             const token = core.getInput('fermyon_token', { required: true });
             yield cloud.login(token);
-            yield actions.build();
+            const buildEnabled = core.getBooleanInput('run_build') === false ? false : true;
+            if (buildEnabled) {
+                yield actions.build();
+            }
             const appUrl = yield actions.deployPreview(prNumber);
             core.setOutput('app-url', appUrl);
         }

--- a/spin/preview/action.yml
+++ b/spin/preview/action.yml
@@ -18,6 +18,10 @@ inputs:
   key_values:
     required: false
     description: 'Pass a key/value (key=value) to all components of the application. You can specify multiple key_values by putting each key/value pair on its own line'
+  run_build:
+    required: false
+    description: 'run `spin build` if enabled (default)'
+    default: true
   variables:
     required: false
     description: 'Pass a variable (variable=value) to all components of the application. You can specify multiple variables by putting each variable/value pair on its own line'

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -17,7 +17,11 @@ async function run(): Promise<void> {
 
     const token = core.getInput('fermyon_token', {required: true})
     await cloud.login(token)
-    await actions.build()
+    const buildEnabled =
+      core.getBooleanInput('run_build') === false ? false : true
+    if (buildEnabled) {
+      await actions.build()
+    }
     const appUrl = await actions.deployPreview(prNumber)
     core.setOutput('app-url', appUrl)
   } catch (error) {


### PR DESCRIPTION
Closes https://github.com/fermyon/actions/issues/70

~~@rajatjindal I ran `make build` locally, hence all of the changes in `dist`.  Do they look okay?  I was surprised at the amount of changes across all of the files (besides the expected run_build logic in `preview/index.js` of course).  Is there a different way to avoid all of the updates?~~ _edit: nevermind, needed to run `npm install && npm run package`_

